### PR TITLE
Notification Center Page Implemented + To Do for what's left

### DIFF
--- a/app/src/main/java/com/example/quacks_app/EntrantHome.java
+++ b/app/src/main/java/com/example/quacks_app/EntrantHome.java
@@ -108,10 +108,6 @@ public class EntrantHome extends AppCompatActivity {
 //            startActivity(new Intent(EntrantHome.this, Waitlist.class));
 //        });
 
-//        notifications.setOnClickListener(view -> {
-//            startActivity(new Intent(EntrantHome.this, Notifications.class));
-//        });
-
         scanQRCode.setOnClickListener(view -> {
             GmsBarcodeScannerOptions options = new GmsBarcodeScannerOptions.Builder()
                     .setBarcodeFormats(Barcode.FORMAT_QR_CODE, Barcode.FORMAT_AZTEC)
@@ -129,6 +125,13 @@ public class EntrantHome extends AppCompatActivity {
                     .addOnCanceledListener(this::finish)
                     .addOnFailureListener(e -> {
                     });
+        });
+
+        notifications.setOnClickListener(v -> {
+            Intent intent = new Intent(EntrantHome.this, NotificationCenter.class);
+            intent.putExtra("User", user);
+            intent.putExtra("Notif_Permissions", nHandler.appEnabled);
+            startActivity(intent);
         });
     }
     /**
@@ -196,6 +199,8 @@ public class EntrantHome extends AppCompatActivity {
                     alert.show();
                 });
                 resultSnackbar.show();
+                nHandler.appEnabled = true;
+                nHandler.phoneEnabled = true;
                 // If denied, from now on show Snackbar that says "Notifications Disabled", with option to change permissions.
             } else {
                 resultSnackbar = Snackbar.make(this, this.findViewById(R.id.notificationsButton).getRootView(), "Notifications Disabled", Snackbar.LENGTH_LONG);
@@ -204,6 +209,8 @@ public class EntrantHome extends AppCompatActivity {
                     alert.show();
                 });
                 resultSnackbar.show();
+                nHandler.appEnabled = false;
+                nHandler.phoneEnabled = false;
             }
         }
     }

--- a/app/src/main/java/com/example/quacks_app/NotificationCenter.java
+++ b/app/src/main/java/com/example/quacks_app/NotificationCenter.java
@@ -1,0 +1,133 @@
+package com.example.quacks_app;
+
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.provider.Settings;
+import android.view.View;
+import android.widget.Button;
+import android.widget.CompoundButton;
+import android.widget.ImageButton;
+import android.widget.ListView;
+import android.widget.Switch;
+import android.widget.TextView;
+import androidx.activity.EdgeToEdge;
+import androidx.appcompat.app.AppCompatActivity;
+import java.util.Objects;
+
+/**
+ * <p>
+ * This is the activity that runs for the Notification Center page in the app.
+ * It allows the entrant to toggle in-app notifications at the top with a switch.</p>
+ * <p>This toggle also controls the display of the Notification Center. If in-app
+ * notifications are disabled, then a screen with a prompt telling the user that
+ * notifcations are disabled appears, and shows them how to enable both in-app notifications
+ * and phone (system) notifications. If in-app notifications are enabled, then the display
+ * instead shows the current unresolved notifications in order from newest to oldest in a list.</p>
+ * <p>When a notification in the list is clicked on, it takes you to a screen with more information
+ * on the event the notification is associated with, and some options for actions based on the context
+ * of the notification.</p>
+ * @author Marko Srnic
+ * @see NotificationHandler
+ * @see EntrantHome
+ * @version 1.0
+ */
+public class NotificationCenter extends AppCompatActivity {
+    //Initializations
+    boolean notifsAllowed;
+    Switch notifToggle;
+    TextView falseTitle, falseWaitlistText, falseAppNotifText, falsePhoneNotifText, trueTitle;
+    Button settingsButton;
+    ImageButton homeButton;
+    ListView notifList;
+
+    /**
+     * This overidden method is the function that loads and implements the display, based on the attributes
+     * that are in the notification_center.xml file.
+     * @param savedInstanceState needed for the super call of this method.
+     */
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        EdgeToEdge.enable(this);
+        setContentView(R.layout.notification_center);
+        //Grab Notification Handler value from previous activity (EntrantHome)
+        notifsAllowed = Objects.requireNonNull(getIntent().getExtras()).getBoolean("Notif_Permissions", false);
+        //Define elements
+        notifToggle = (Switch) findViewById(R.id.appNotifsSwitch);
+        falseTitle = findViewById(R.id.notificationFalseTitle);
+        falseWaitlistText = findViewById(R.id.notificationFalseText);
+        falseAppNotifText = findViewById(R.id.notificationFalseText2);
+        falsePhoneNotifText = findViewById(R.id.notificationFalseText3);
+        settingsButton = (Button) findViewById(R.id.notificationSettingsButton);
+        homeButton = (ImageButton) findViewById(R.id.homeIcon);
+        trueTitle = findViewById(R.id.notificationTrueTitle);
+        notifList = findViewById(R.id.notif_list);
+        //Display Notification List or disabled prompt, depending on if notifications are allowed
+        //THIS IS ON INITIAL STARTUP OF THE ACTIVITY ONLY, and is therefore needed because the switch does not exist yet.
+        if (notifsAllowed) {
+            notifToggle.setChecked(true);
+            falseTitle.setVisibility(View.GONE);
+            falseWaitlistText.setVisibility(View.GONE);
+            falseAppNotifText.setVisibility(View.GONE);
+            falsePhoneNotifText.setVisibility(View.GONE);
+            settingsButton.setVisibility(View.GONE);
+            trueTitle.setVisibility(View.VISIBLE);
+            notifList.setVisibility(View.VISIBLE);
+        } else {
+            notifToggle.setChecked(false);
+            falseTitle.setVisibility(View.VISIBLE);
+            falseWaitlistText.setVisibility(View.VISIBLE);
+            falseAppNotifText.setVisibility(View.VISIBLE);
+            falsePhoneNotifText.setVisibility(View.VISIBLE);
+            settingsButton.setVisibility(View.VISIBLE);
+            trueTitle.setVisibility(View.GONE);
+            notifList.setVisibility(View.GONE);
+        }
+        //Send user to Settings App's notification settings for this app when clicked.
+        settingsButton.setOnClickListener(v -> {
+            Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+            Uri URI = Uri.fromParts("package", getPackageName(), null);
+            intent.setData(URI);
+            startActivity(intent);
+        });
+        //When the home button in the bottom bar is clicked, return back to entrant home page.
+        homeButton.setOnClickListener(v -> {
+            finish();
+        });
+        //Listener for the notifications switch toggle at the top of the page.
+        //Flips the display of the notification center and enables/disables in-app notifications.
+        notifToggle.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            /**
+             * A method for Switch elements that defines what occurs when a Switch is toggled.
+             * @param buttonView - the button (in this case Switch) whose state has changed.
+             * @param isChecked - the boolean that enumerates whether the state is on (true) or off (false).
+             */
+            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                //If on/true, enable the Notification Center and hide settings prompt.
+                if (isChecked) {
+                    notifsAllowed = true;
+                    notifToggle.setChecked(true);
+                    falseTitle.setVisibility(View.GONE);
+                    falseWaitlistText.setVisibility(View.GONE);
+                    falseAppNotifText.setVisibility(View.GONE);
+                    falsePhoneNotifText.setVisibility(View.GONE);
+                    settingsButton.setVisibility(View.GONE);
+                    trueTitle.setVisibility(View.VISIBLE);
+                    notifList.setVisibility(View.VISIBLE);
+                //If off/false, enable the Notification Settings prompt and hide the Notification Center.
+                } else {
+                    notifsAllowed = false;
+                    notifToggle.setChecked(false);
+                    falseTitle.setVisibility(View.VISIBLE);
+                    falseWaitlistText.setVisibility(View.VISIBLE);
+                    falseAppNotifText.setVisibility(View.VISIBLE);
+                    falsePhoneNotifText.setVisibility(View.VISIBLE);
+                    settingsButton.setVisibility(View.VISIBLE);
+                    trueTitle.setVisibility(View.GONE);
+                    notifList.setVisibility(View.GONE);
+                }
+            }
+        });
+    }
+}

--- a/app/src/main/java/com/example/quacks_app/NotificationHandler.java
+++ b/app/src/main/java/com/example/quacks_app/NotificationHandler.java
@@ -16,17 +16,39 @@ import androidx.core.app.NotificationManagerCompat;
 
 import java.util.ArrayList;
 
+/**
+ *
+ * <p>This class is responsible for instantiating and managing system notifications for this app.
+ * It creates the channel that the notifications will be broadcast to, the notifications themselves,
+ * and ensures notification permissions are confirmed and acknowledged.</p>
+ * <p>Note that due to the nature of permission requests in applications, there is some necessary functionality
+ * that only exists in activities that employ this class, that handle said functionality on this class's behalf.</p>
+ * @author Marko Srnic
+ * @see EntrantHome
+ * @version 1.1
+ */
 public class NotificationHandler {
+    //Declaration of attributes
     public static final String EVENTS_CHANNEL_ID = "events_channel";
     private static final int REQUEST_CODE = 1;
     private ArrayList<Integer> notifIDs;
     private int newNotifID;
+    public boolean appEnabled;
+    public boolean phoneEnabled;
 
+    /**
+     * The constructor for the handler. All it does is set the first notification ID and define the notification list.
+     */
     public NotificationHandler() {
         this.newNotifID = 1;
         notifIDs = new ArrayList<>();
     }
 
+    /**
+     * Creates the notification channel that notifications will be broadcast to.
+     * This channel is called Events Channel, and is "A channel for sending updates about events you expressed interest in.", you as in the user.
+     * @param context - the activity that this channel is being created in.
+     */
     public static void createChannel(Context context) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
@@ -39,22 +61,54 @@ public class NotificationHandler {
         }
     }
 
+    /**
+     * This method creates and emits a notification that has a small, always visible message.
+     * The notification is associated with the created notification channel, so there must be an existing channel before this method can work.
+     * Additionally, there is a suppressed SecurityException for when a notification is sent, specifically in
+     * "notificationManagerCompat.notify(newNotifID, builder.build());", where there is a worry by the system that a
+     * notification may be sent without a check of the proper permissions. These are intentionally suppressed because in a given activity,
+     * this method is never called unless notifications are allowed in the first place, effectively checking for permission first before allowing
+     * any notifications to be made.
+     * @param context - The activity the notification is sent over.
+     * @param title - The main title of the notification.
+     * @param messageShort - The content of the notification.
+     * @param icon - An image resource that serves as the logo for the notification.
+     */
     @SuppressLint("MissingPermission")
     public void sendNotification(Context context, String title, String messageShort, int icon) {
+        //Build the notification
         NotificationCompat.Builder builder = new NotificationCompat.Builder(context, EVENTS_CHANNEL_ID)
                 .setSmallIcon(icon)
                 .setContentTitle(title)
                 .setContentText(messageShort)
                 .setPriority(NotificationCompat.PRIORITY_HIGH)
                 .setAutoCancel(true);
+        //Set up the emitter and emit the notification
         NotificationManagerCompat notificationManagerCompat = NotificationManagerCompat.from(context);
         notificationManagerCompat.notify(newNotifID, builder.build());
+        //Add the notification to the active list and associate it with an ID
         notifIDs.add(newNotifID);
         newNotifID += 1;
     }
 
+    /**
+     * This method creates and emits a notification that has a small, always visible message.
+     * It also contains a field for a larger/longer message that can be viewed in the system's notification tab by swiping up.
+     * The notification is associated with the created notification channel, so there must be an existing channel before this method can work.
+     * Additionally, there is a suppressed SecurityException for when a notification is sent, specifically in
+     * "notificationManagerCompat.notify(newNotifID, builder.build());", where there is a worry by the system that a
+     * notification may be sent without a check of the proper permissions. These are intentionally suppressed because in a given activity,
+     * this method is never called unless notifications are allowed in the first place, effectively checking for permission first before allowing
+     * any notifications to be made.
+     * @param context - The activity the notification is sent over.
+     * @param title - The main title of the notification.
+     * @param messageShort - The content of the notification.
+     * @param messageLong - The content of the longer text portion of the notification.
+     * @param icon - An image resource that serves as the logo for the notification.
+     */
     @SuppressLint("MissingPermission")
     public void sendNotificationVerbose(Context context, String title, String messageShort, String messageLong, int icon) {
+        //Build the notification
         NotificationCompat.Builder builder = new NotificationCompat.Builder(context, EVENTS_CHANNEL_ID)
                 .setSmallIcon(icon)
                 .setContentTitle(title)
@@ -63,28 +117,42 @@ public class NotificationHandler {
                         .bigText(messageLong))
                 .setPriority(NotificationCompat.PRIORITY_HIGH)
                 .setAutoCancel(true);
+        //Set up the emitter and emit the notification
         NotificationManagerCompat notificationManagerCompat = NotificationManagerCompat.from(context);
         notificationManagerCompat.notify(newNotifID, builder.build());
+        //Add the notification to the active list and associate it with an ID
         notifIDs.add(newNotifID);
         newNotifID += 1;
     }
 
-    @SuppressLint("MissingPermission")
-    public void sendActionedNotificationVerbose(Context context, String title, String messageShort, String messageLong, int icon, Intent intent) {
-        NotificationCompat.Builder builder = new NotificationCompat.Builder(context, EVENTS_CHANNEL_ID)
-                .setSmallIcon(icon)
-                .setContentTitle(title)
-                .setContentText(messageShort)
-                .setStyle(new NotificationCompat.BigTextStyle()
-                        .bigText(messageLong))
-                .setPriority(NotificationCompat.PRIORITY_HIGH)
-                .setAutoCancel(true);
-        NotificationManagerCompat notificationManagerCompat = NotificationManagerCompat.from(context);
-        notificationManagerCompat.notify(newNotifID, builder.build());
-        notifIDs.add(newNotifID);
-        newNotifID += 1;
-    }
+    // UNFINISHED NOTIFICATION TYPE, MAY BE UNNEEDED (duplicate of verbose notification)
 
+//    @SuppressLint("MissingPermission")
+//    public void sendActionedNotificationVerbose(Context context, String title, String messageShort, String messageLong, int icon, Intent intent) {
+//        //Build the notification
+//        NotificationCompat.Builder builder = new NotificationCompat.Builder(context, EVENTS_CHANNEL_ID)
+//                .setSmallIcon(icon)
+//                .setContentTitle(title)
+//                .setContentText(messageShort)
+//                .setStyle(new NotificationCompat.BigTextStyle()
+//                        .bigText(messageLong))
+//                .setPriority(NotificationCompat.PRIORITY_HIGH)
+//                .setAutoCancel(true);
+//        //Set up the emitter and emit the notification
+//        NotificationManagerCompat notificationManagerCompat = NotificationManagerCompat.from(context);
+//        notificationManagerCompat.notify(newNotifID, builder.build());
+//        //Add the notification to the active list and associate it with an ID
+//        notifIDs.add(newNotifID);
+//        newNotifID += 1;
+//    }
+
+    /**
+     * This method explicitly asks for notification permission from the user, using the built-in
+     * standardized permission prompt by Android. Additionally, because these permissions were
+     * introduced on a specific version of Android, there is a check to ensure the user has an OS that is
+     * at least a specific threshold OS (the one that introduced the permissions.)
+     * @param activity - the activity that is asking for permission.
+     */
     public static void askForPermission(Activity activity) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             requestPermissions(activity, new String[]{Manifest.permission.POST_NOTIFICATIONS}, REQUEST_CODE);

--- a/app/src/main/res/layout/notification_center.xml
+++ b/app/src/main/res/layout/notification_center.xml
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#F0E0E0"
+    android:padding="16dp"
+    android:fitsSystemWindows="true"
+    tools:context=".MainActivity">
+
+    <TextView
+        android:id="@+id/notificationFalseTitle"
+        android:layout_width="380dp"
+        android:layout_height="30dp"
+        android:layout_marginBottom="10dp"
+        android:fontFamily="@font/yaldevi_semibold"
+        android:text="Notifications Blocked!"
+        android:textAlignment="center"
+        android:textColor="@color/text"
+        android:textSize="24sp"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toTopOf="@+id/notificationFalseText"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="1.0" />
+
+    <TextView
+        android:id="@+id/notificationFalseText"
+        android:layout_width="247dp"
+        android:layout_height="71dp"
+        android:layout_marginBottom="8dp"
+        android:fontFamily="@font/yaldevi_semibold"
+        android:text="To see your acceptance status for your events, please visit the Waitlist tab on the homepage."
+        android:textAlignment="center"
+        android:textColor="@color/text"
+        android:textSize="16sp"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toTopOf="@+id/notificationFalseText2"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="1.0" />
+
+    <TextView
+        android:id="@+id/notificationFalseText2"
+        android:layout_width="244dp"
+        android:layout_height="216dp"
+        android:fontFamily="@font/yaldevi_semibold"
+        android:text="To change your app notification permissions, use the switch toggle found here. Your phone will only notify you if notifications are allowed both here and on your device. To change your phone notification permissions for the app, please modify them in your device's Settings app."
+        android:textAlignment="center"
+        android:textColor="@color/text"
+        android:textSize="16sp"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toTopOf="@+id/notificationFalseText3"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.518"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="1.0" />
+
+    <TextView
+        android:id="@+id/notificationFalseText3"
+        android:layout_width="240dp"
+        android:layout_height="37dp"
+        android:layout_marginBottom="200dp"
+        android:fontFamily="@font/yaldevi_semibold"
+        android:text="(Requires app restart)"
+        android:textAlignment="center"
+        android:textColor="@color/text"
+        android:textSize="16sp"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toTopOf="@+id/bottomNavigation"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <TextView
+        android:id="@+id/notificationTrueTitle"
+        android:layout_width="380dp"
+        android:layout_height="30dp"
+        android:fontFamily="@font/yaldevi_semibold"
+        android:text="Notification Center"
+        android:textAlignment="center"
+        android:textColor="@color/text"
+        android:textSize="24sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/appNotifsSwitch" />
+
+    <ListView
+        android:id="@+id/notif_list"
+        android:layout_width="400dp"
+        android:layout_height="520dp"
+        android:background="@color/base"
+        android:clickable="true"
+        android:focusable="true"
+        app:layout_constraintBottom_toTopOf="@+id/bottomNavigation"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+    </ListView>
+
+    <LinearLayout
+        android:id="@+id/bottomNavigation"
+        android:layout_width="match_parent"
+        android:layout_height="60dp"
+        android:background="@color/white"
+        android:gravity="center"
+        android:orientation="horizontal"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent">
+
+        <ImageButton
+            android:id="@+id/homeIcon"
+            android:layout_width="50dp"
+            android:layout_height="50dp"
+            android:layout_marginStart="30dp"
+            android:layout_marginEnd="40dp"
+            android:background="@drawable/round_admin_button"
+            android:padding="5dp"
+            android:scaleType="fitXY"
+            android:src="@drawable/icon_home" />
+    </LinearLayout>
+
+
+    <Button
+        android:id="@+id/notificationSettingsButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:backgroundTint="#f5ebeb"
+        android:fontFamily="@font/yaldevi_semibold"
+        android:text="Settings"
+        android:textAlignment="center"
+        android:textColor="@color/text"
+        android:textSize="16sp"
+        app:layout_constraintBottom_toTopOf="@+id/bottomNavigation"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/notificationFalseText3"
+        app:layout_constraintVertical_bias="0.3" />
+
+    <Switch
+        android:id="@+id/appNotifsSwitch"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="In-App Notifications"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Implemented Notification Center Page, with permission toggle and settings prompt for system notifications. Javadocs for NotificationCenter and NotificationHandler also complete.
To Do:
1. A function (in NotificationHandler) that queries the database for all notifications that are to be received by the user of this device. Store the notification objects in a list of some kind.
2. In the Notification Center, for each Notification that has arrived, create a new selection in the ListView for it, and grab + store the Event associated with the Notification for display later.
3. When a selection is made from the Notification Center's ListView, a fragment/popup appears that gives the user more information about what event the notification is referring to, and what has occurred. This window should also let the user take an action, i.e. accept/decline an invitation when chosen.
4. If there is a response in 3., send it to the database in whatever way the event host can access it.